### PR TITLE
Clean up log format

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,5 +58,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  # config.log_formatter = ::Logger::Formatter.new
+  config.logger.formatter = proc do |severity, _time, _progname, message|
+    "#{severity}: #{message}\n"
+  end
 end


### PR DESCRIPTION
Don't display time as already done in docker / heroku