### PR TITLE
Remove Paper Trail test helpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,6 @@ if ENV['COVERAGE']
   require 'simplecov'
 
   SimpleCov.minimum_coverage 100
-
   SimpleCov.start 'rails'
 end
 
@@ -10,7 +9,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
-require 'paper_trail/frameworks/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
Remove Paper Trail test helpers as they are broken, and manually tested
in spec/support/models/default.rb