### PR TITLE
Fix asset host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,11 @@ module Cms
     # Raises error for missing translations
     config.action_view.raise_on_missing_translations = true
 
+    if ENV['ASSET_HOST']
+      # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+      config.action_controller.asset_host = ENV['ASSET_HOST']
+    end
+
     unless ENV['DISABLE_SSL']
       # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
       config.force_ssl = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -34,8 +34,3 @@ else
     'Cache-Control' => "public, max-age=#{1.year.to_i}"
   }
 end
-
-if ENV['ASSET_HOST']
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  Rails.application.config.action_controller.asset_host = ENV['ASSET_HOST']
-end


### PR DESCRIPTION
For some reason, asset host does not work in initializers when NewRelic
is enabled.