### PR TITLE
Change api error responses

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -12,8 +12,8 @@ class API < Grape::API
   helpers ::Helpers::Authentication
   helpers ::Helpers::Errors
 
-  rescue_from ActiveRecord::RecordNotFound, with: :page_not_found
-  rescue_from Pundit::NotAuthorizedError, with: :page_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :forbidden
+  rescue_from Pundit::NotAuthorizedError, with: :forbidden
 
   namespace do
     after(&:verify_authorized)

--- a/app/api/helpers/errors.rb
+++ b/app/api/helpers/errors.rb
@@ -1,7 +1,23 @@
 module Helpers
   module Errors
+    def forbidden
+      message = {
+        'http_status_code' => 403,
+        'error' => 'Forbidden',
+        'message' => 'Either you do not have permission or the resource was not found'
+      }
+
+      error!(message, 403)
+    end
+
     def page_not_found
-      error!('404 not found', 404)
+      message = {
+        'http_status_code' => 404,
+        'error' => 'Not found',
+        'message' => 'Please check API documentation'
+      }
+
+      error!(message, 404)
     end
   end
 end

--- a/spec/requests/api/authorization_spec.rb
+++ b/spec/requests/api/authorization_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'API Authorization' do
       let(:message) { FactoryBot.create(:message) }
       let(:request_path_id) { message.uuid }
 
-      include_examples 'renders json page not found'
+      include_examples 'renders json forbidden'
     end
   end
 end

--- a/spec/requests/api/unknown_routes_spec.rb
+++ b/spec/requests/api/unknown_routes_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'API Unknown routes' do
   context 'with missing record' do
     let(:request_path) { '/api/messages/badmessage' }
 
-    include_examples 'renders json page not found'
+    include_examples 'renders json forbidden'
   end
 
   context 'with unkown extension' do

--- a/spec/support/requests.rb
+++ b/spec/support/requests.rb
@@ -38,10 +38,35 @@ end
 
 RSpec.configuration.include_context 'with requests', type: :request
 
+RSpec.shared_examples 'renders json forbidden' do
+  let(:expected_body) do
+    {
+      'http_status_code' => 403,
+      'error' => 'Forbidden',
+      'message' => 'Either you do not have permission or the resource was not found'
+    }
+  end
+
+  it 'renders json forbidden' do
+    request_page(expected_status: 403)
+
+    expect(json_body).to eq(expected_body)
+  end
+end
+
 RSpec.shared_examples 'renders json page not found' do
+  let(:expected_body) do
+    {
+      'http_status_code' => 404,
+      'error' => 'Not found',
+      'message' => 'Please check API documentation'
+    }
+  end
+
   it 'renders json page not found' do
     request_page(expected_status: 404)
-    expect(json_body).to eq('error' => '404 not found')
+
+    expect(json_body).to eq(expected_body)
   end
 end
 


### PR DESCRIPTION
Return 403 Forbidden for permissions so easier to debug mistakes. Make
error messages more verbose.

Resolves #915