### PR TITLE
Make S3 files private

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,8 +11,7 @@
     "description": "A Content Management System (CMS) written with Ruby on Rails",
     "env": {
         "ASSET_HOST": {
-            "description": "Sets the rails asset host",
-            "required": false
+            "description": "Sets the rails asset host"
         },
         "AWS_ACCESS_KEY_ID": {
             "description": "The Amazon Web Services IAM user key for S3 and optionally SES"

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -1,4 +1,6 @@
 class ApplicationUploader < CarrierWave::Uploader::Base
+  delegate :public_url, to: :file
+
   storage :fog if ENV['AWS_S3_BUCKET']
 
   def uuid

--- a/app/views/images/index.html.haml
+++ b/app/views/images/index.html.haml
@@ -5,6 +5,6 @@
 .thumbnail-grid
   - @images.each do |image|
     .thumbnail-grid__container
-      = link_to(image.file.url, target: '_blank', class: 'thumbnail-grid__link') do
-        = image_tag(image.file.span3.url, alt: image.name)
+      = link_to(image.file.public_url, target: '_blank', class: 'thumbnail-grid__link') do
+        = image_tag(image.file.span3.public_url, alt: image.name)
         %h5.thumbnail-grid__name= image.name

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }
     %title= page_title(@site, content_for(:title))
     = stylesheet_link_tag 'application', 'data-turbolinks-track': 'reload', media: 'all'
-    = stylesheet_link_tag @site.stylesheet.url, 'data-turbolinks-track': 'reload', media: 'all' if @site.stylesheet.url
+    = stylesheet_link_tag @site.stylesheet.public_url, 'data-turbolinks-track': 'reload', media: 'all' if @site.stylesheet_filename
     = render 'layouts/rollbar' if ENV['ROLLBAR_CLIENT_TOKEN']
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload', crossorigin: 'anonymous'
     = content_for(:head)

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -54,7 +54,8 @@ Resources:
         Origins:
           - DomainName: !GetAtt S3Bucket.DomainName
             Id: S3
-            S3OriginConfig: {}
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
           - CustomOriginConfig:
               OriginProtocolPolicy: https-only
               OriginSSLProtocols:
@@ -63,6 +64,12 @@ Resources:
                 - TLSv1
             DomainName: !Sub "${AWS::StackName}.herokuapp.com"
             Id: App
+
+  CloudFrontOriginAccessIdentity:
+    Type: "AWS::CloudFront::CloudFrontOriginAccessIdentity"
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Ref "AWS::StackName"
 
   GlueDatabase:
     Type: "AWS::Glue::Database"
@@ -90,9 +97,9 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
-            Action: "sts:AssumeRole"
             Principal:
               Service: glue.amazonaws.com
+            Action: "sts:AssumeRole"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
       Policies:
@@ -171,6 +178,19 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  S3BucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${CloudFrontOriginAccessIdentity}"
+            Action: "s3:GetObject"
+            Resource: !Sub "${S3Bucket.Arn}/*"
+
   S3LogsBucket:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -196,9 +216,9 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
-            Action: "s3:PutObject"
             Principal:
               AWS: "arn:aws:iam::719734659904:root"
+            Action: "s3:PutObject"
             Resource: !Sub "${S3LogsBucket.Arn}/papertrail/*"
 
   SNSTopic:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -21,6 +21,8 @@ CarrierWave.configure do |config|
     }
 
     config.fog_directory = bucket
+
+    config.fog_public = false
   else
     config.storage = :file
     config.base_path = '/uploads'

--- a/spec/features/images/index_spec.rb
+++ b/spec/features/images/index_spec.rb
@@ -15,19 +15,19 @@ RSpec.feature 'Images index' do
     links = all('article a')
     expect(links.size).to eq 3
 
-    expect(links[0]['href']).to eq image_a.file.url
+    expect(links[0]['href']).to eq image_a.file.public_url
     image1 = links[0].find('img')
-    expect(image1['src']).to eq image_a.file.span3.url
+    expect(image1['src']).to eq image_a.file.span3.public_url
     expect(image1['alt']).to eq image_a.name
 
-    expect(links[1]['href']).to eq image_b.file.url
+    expect(links[1]['href']).to eq image_b.file.public_url
     image2 = links[1].find('img')
-    expect(image2['src']).to eq image_b.file.span3.url
+    expect(image2['src']).to eq image_b.file.span3.public_url
     expect(image2['alt']).to eq image_b.name
 
-    expect(links[2]['href']).to eq image_c.file.url
+    expect(links[2]['href']).to eq image_c.file.public_url
     image3 = links[2].find('img')
-    expect(image3['src']).to eq image_c.file.span3.url
+    expect(image3['src']).to eq image_c.file.span3.public_url
     expect(image3['alt']).to eq image_c.name
   end
 end

--- a/spec/features/sites/css_spec.rb
+++ b/spec/features/sites/css_spec.rb
@@ -15,7 +15,9 @@ RSpec.feature 'Site CSS' do
     click_button 'Update Site'
 
     expect(page).to have_content 'Site successfully updated'
-    expect(page).to have_selector "link[href=\"#{site.reload.stylesheet.url}\"]", visible: false
+    uuid = File.basename(site.reload.stylesheet_filename, '.css')
+    url = File.join('http://localhost:37511', 'stylesheets', uuid, 'original.css')
+    expect(page).to have_selector "link[href=\"#{url}\"]", visible: false
 
     navigate_via_topbar menu: 'Site', title: 'CSS', icon: 'file'
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Image do
     end
 
     it 'stores filename as url' do
-      expect(image.file.url).to eq filename
+      expect(image.file.public_url).to eq filename
     end
 
     it 'recreates versions' do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Site do
     end
 
     it 'is saved in the stylesheets directory on s3' do
-      expect(site.stylesheet.url).to eq File.join(
+      expect(site.stylesheet.public_url).to eq File.join(
         'http://localhost:37511', 'stylesheets', uuid, 'original.css'
       )
     end

--- a/spec/uploaders/carrier_wave_spec.rb
+++ b/spec/uploaders/carrier_wave_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CarrierWave do
   let(:site) { FactoryBot.create(:site) }
   let(:uploader) { StylesheetUploader.new(site) }
 
-  it 'sets cache as 1 year' do
+  before do
     uploader.store! StringUploader.new('stylesheet.css', 'bob')
+  end
+
+  it 'sets cache as 1 year' do
     expect(uploaded_file.cache_control).to eq 'public, max-age=31557600'
+  end
+
+  it 'uploads files as private' do
+    expect(uploader.fog_public).to eq false
   end
 end


### PR DESCRIPTION
Make S3 files private and give permission for cloudfront to view them,
so people cannot use the S3 URL.

Delivers #947