### PR TITLE
Split ASSET_HOST and AWS_S3_ASSET_HOST

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,10 +1,10 @@
-ASSET_HOST=http://localhost:37511
 AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
 AWS_COGNITO_CLIENT_ID=xxxx
 AWS_COGNITO_CLIENT_SECRET=xxxx
 AWS_COGNITO_DOMAIN=http://localhost:37511
 AWS_COGNITO_USER_POOL_ID=xxxx
 AWS_REGION=eu-west-1
+AWS_S3_ASSET_HOST=http://localhost:37511
 AWS_S3_BUCKET=obduk-cms-test
 AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxx
 AWS_STUB=true

--- a/app.json
+++ b/app.json
@@ -31,6 +31,9 @@
         "AWS_REGION": {
             "description": "The Amazon Web Services region"
         },
+        "AWS_S3_ASSET_HOST": {
+            "description": "The Cloudfront URL for the S3 bucket"
+        },
         "AWS_S3_BUCKET": {
             "description": "The Amazon Web Services S3 bucket name"
         },

--- a/cloudformation/app.yaml
+++ b/cloudformation/app.yaml
@@ -22,6 +22,9 @@ Outputs:
   AwsRegion:
     Description: "Value for AWS_REGION"
     Value: !Ref "AWS::Region"
+  AwsS3AssetHost:
+    Description: "Value for AWS_S3_ASSET_HOST"
+    Value: !Sub "https://${CloudFront.DomainName}"
   AwsS3Bucket:
     Description: "Value for AWS_S3_BUCKET"
     Value: !Ref S3Bucket

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,9 +5,7 @@ CarrierWave.configure do |config|
     bucket = ENV.fetch('AWS_S3_BUCKET')
     region = ENV.fetch('AWS_REGION')
 
-    default_host = "https://#{bucket}.s3-#{region}.amazonaws.com"
-
-    config.asset_host = ENV['ASSET_HOST'] || default_host
+    config.asset_host = ENV.fetch('AWS_S3_ASSET_HOST')
 
     config.fog_attributes = {
       cache_control: "public, max-age=#{1.year.to_i}"

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -3,7 +3,12 @@ SecureHeaders::Configuration.default do |config|
 
   config.referrer_policy = 'strict-origin-when-cross-origin'
 
-  asset_src = ["'self'", "'unsafe-inline'", ENV['ASSET_HOST']].compact
+  asset_src = [
+    "'self'",
+    "'unsafe-inline'",
+    ENV['ASSET_HOST'],
+    ENV['AWS_S3_ASSET_HOST']
+  ].compact
 
   script_src = asset_src + [
     'https://www.google-analytics.com',

--- a/spec/features/stylesheet_spec.rb
+++ b/spec/features/stylesheet_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Stylesheet' do
     click_button 'Create Stylesheet'
 
     expect(page).to have_content 'Stylesheet successfully updated'
-    url = "http://localhost:37511/css/#{site.uid}-#{site.stylesheet.updated_at.to_i}.css"
+    url = "/css/#{site.uid}-#{site.stylesheet.updated_at.to_i}.css"
     expect(page).to have_selector "link[href=\"#{url}\"]", visible: false
 
     navigate_via_topbar menu: 'Site', title: 'CSS', icon: 'svg.fa-file.fa-fw'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ApplicationHelper do
     let!(:stylesheet) { FactoryBot.build(:stylesheet, site: site) }
 
     it 'returns stylesheet path' do
-      url = "http://localhost:37511/css/#{site.uid}-#{stylesheet.updated_at.to_i}.css"
+      url = "/css/#{site.uid}-#{stylesheet.updated_at.to_i}.css"
 
       expect(helper.site_stylesheet(site)).to eq url
     end


### PR DESCRIPTION
Allows ASSET_HOST not be set on Staging so new changes can be tested.